### PR TITLE
feat: docker compose

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Auto detect text files and perform LF normalization
+* text=auto

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM denoland/deno:latest
+
+WORKDIR /app
+
+RUN apt update && apt install -y ca-certificates git openssh-client
+
+CMD [ "run", "-A", "serve.ts" ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,25 @@
+version: "3.9"
+
+services:
+  lume_cms:
+    container_name: lume_cms
+    build:
+      context: .
+      dockerfile: Dockerfile
+    expose:
+      - 8000:8000
+    volumes:
+      - .:/app
+      # - ~/.ssh/id_rsa:/root/.ssh/id_rsa
+      - ~/.gitconfig:/etc/.gitconfig
+
+  caddy:
+    container_name: lume_cms_caddy
+    image: caddy
+    depends_on:
+      - lume_cms
+    restart: unless-stopped
+    command: caddy reverse-proxy --from https://${CMS_DEPLOY_DOMAIN:-localhost}:443 --to http://lume_cms:8000
+    ports:
+      - 80:80
+      - 443:443


### PR DESCRIPTION
I'm not quite sure how to test it at the moment, It feels like git config is going to be the hard part.

Users need to `git clone user/repo` and configure environment variables (`$CMS_DEPLOY_DOMAIN`) first.

```ts
// serve.ts
import site from "./_config.ts";
import cms from "./_cms.ts";
import { adapter } from "lume/cms.ts";

const app = await adapter({ site, cms });

Deno.serve(app.fetch);
```

```dotenv
# .env
CMS_DEPLOY_DOMAIN = "example.com"
```